### PR TITLE
Add Static Website with S3 and CloudFront

### DIFF
--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -1,0 +1,82 @@
+name: 'Terraform Destroy'
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to destroy (dev/staging/prod)'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
+      confirmation:
+        description: 'Type "destroy" to confirm deletion of resources'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  terraform-destroy:
+    name: 'Terraform Destroy'
+    runs-on: ubuntu-latest
+    if: github.event.inputs.confirmation == 'destroy'
+    env:
+      TF_VAR_environment: ${{ github.event.inputs.environment }}
+      TF_VAR_bucket_name: ${{ secrets.TF_VAR_BUCKET_NAME || format('static-website-{0}', github.run_id) }}
+    
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Empty S3 Bucket
+        run: |
+          BUCKET_NAME=$(terraform output -raw s3_bucket_name || echo "")
+          if [ ! -z "$BUCKET_NAME" ]; then
+            echo "Emptying bucket $BUCKET_NAME before destroy"
+            aws s3 rm s3://$BUCKET_NAME --recursive
+          else
+            echo "No bucket name found in outputs, skipping bucket emptying"
+          fi
+        continue-on-error: true
+
+      - name: Terraform Destroy
+        id: destroy
+        run: terraform destroy -auto-approve -input=false
+
+      - name: Post Destroy Results
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Destroy Complete ✅
+            
+            *Resources in \`${{ env.TF_VAR_environment }}\` environment have been destroyed by @${{ github.actor }}*`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number || 1,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            });
+        continue-on-error: true

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,197 @@
+name: 'Terraform CI/CD Pipeline'
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to (dev/staging/prod)'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  terraform-validate:
+    name: 'Terraform Validate'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate
+
+      - name: Post Validation Results
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome == 'success' && '✅' || '❌' }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome == 'success' && '✅' || '❌' }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome == 'success' && '✅' || '❌' }}\`
+            
+            *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+  terraform-plan:
+    name: 'Terraform Plan'
+    needs: terraform-validate
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    env:
+      TF_VAR_environment: ${{ github.event.inputs.environment || 'dev' }}
+      TF_VAR_bucket_name: ${{ secrets.TF_VAR_BUCKET_NAME || format('static-website-{0}', github.run_id) }}
+    
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color -input=false
+        continue-on-error: true
+
+      - name: Post Plan Results
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Plan 📝\`${{ steps.plan.outcome == 'success' && '✅' || '❌' }}\`
+            
+            <details><summary>Show Plan</summary>
+            
+            \`\`\`terraform
+            ${{ steps.plan.outputs.stdout || steps.plan.outputs.stderr }}
+            \`\`\`
+            
+            </details>
+            
+            *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+  terraform-apply:
+    name: 'Terraform Apply'
+    needs: terraform-plan
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    env:
+      TF_VAR_environment: ${{ github.event.inputs.environment || 'dev' }}
+      TF_VAR_bucket_name: ${{ secrets.TF_VAR_BUCKET_NAME || format('static-website-{0}', github.run_id) }}
+    
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.0
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Apply
+        id: apply
+        run: terraform apply -auto-approve -input=false
+
+      - name: Extract CloudFront Domain
+        id: cloudfront
+        run: |
+          DOMAIN=$(terraform output -raw cloudfront_domain_name)
+          echo "domain=$DOMAIN" >> $GITHUB_OUTPUT
+
+      - name: Post Apply Results
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue || context.payload.pull_request || { number: 0 };
+            const isPR = !!context.payload.pull_request;
+            const domain = '${{ steps.cloudfront.outputs.domain }}';
+            
+            const output = `#### Terraform Apply Complete ✅
+            
+            🌐 **Website URL**: https://${domain}
+            
+            *Deployed by: @${{ github.actor }}, Environment: \`${{ env.TF_VAR_environment }}\`*`;
+            
+            if (isPR && issue.number > 0) {
+              github.rest.issues.createComment({
+                issue_number: issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used for local dev
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore lock files
+.terraform.lock.hcl

--- a/README-static-website.md
+++ b/README-static-website.md
@@ -1,0 +1,84 @@
+# Static Website with S3 and CloudFront
+
+This module creates an AWS S3 bucket configured for static website hosting and a CloudFront distribution to serve the content securely and with improved performance.
+
+## Features
+
+- S3 bucket configured for website hosting
+- CloudFront distribution with Origin Access Control
+- Secure bucket policy that only allows access from CloudFront
+- Sample HTML files (index.html and error.html)
+- IPv6 support
+
+## Usage
+
+```hcl
+module "static_website" {
+  source = "./"
+  
+  bucket_name = "my-static-website-bucket"
+  environment = "dev"
+}
+```
+
+## Prerequisites
+
+- AWS account with appropriate permissions
+- Terraform installed (version >= 1.2.0)
+- AWS CLI configured
+
+## Deployment Instructions
+
+1. Clone this repository
+2. Navigate to the directory containing the Terraform files
+3. Create a `terraform.tfvars` file based on the example file
+4. Initialize Terraform:
+   ```
+   terraform init
+   ```
+5. Plan the deployment:
+   ```
+   terraform plan
+   ```
+6. Apply the configuration:
+   ```
+   terraform apply
+   ```
+7. After successful deployment, the CloudFront domain name will be displayed in the outputs
+
+## Uploading Content
+
+You can upload additional content to the S3 bucket using the AWS CLI:
+
+```bash
+aws s3 sync ./your-website-files/ s3://your-bucket-name/
+```
+
+Or add more `aws_s3_object` resources in the Terraform configuration.
+
+## Cleanup
+
+To destroy all resources created by this Terraform configuration:
+
+```
+terraform destroy
+```
+
+## Variables
+
+| Name | Description | Type | Default |
+|------|-------------|------|--------|
+| region | AWS region to deploy resources | string | "us-east-1" |
+| bucket_name | Name of the S3 bucket | string | - |
+| environment | Environment name | string | "dev" |
+| cloudfront_price_class | CloudFront price class | string | "PriceClass_100" |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| s3_bucket_name | Name of the S3 bucket |
+| s3_bucket_arn | ARN of the S3 bucket |
+| s3_website_endpoint | S3 website endpoint |
+| cloudfront_distribution_id | ID of the CloudFront distribution |
+| cloudfront_domain_name | Domain name of the CloudFront distribution |

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,107 @@
+# Setup Guide for GitHub Actions with Terraform and AWS
+
+This guide explains how to set up the required secrets and configurations for deploying the static website using GitHub Actions.
+
+## Required GitHub Secrets
+
+Add the following secrets to your GitHub repository:
+
+1. **AWS Credentials**:
+   - `AWS_ACCESS_KEY_ID`: Your AWS access key
+   - `AWS_SECRET_ACCESS_KEY`: Your AWS secret key
+   - `AWS_REGION`: The AWS region to deploy to (e.g., `us-east-1`)
+
+2. **Terraform Variables**:
+   - `TF_VAR_BUCKET_NAME`: The name for your S3 bucket (must be globally unique)
+
+3. **Optional - Terraform Cloud**:
+   - `TF_API_TOKEN`: Your Terraform Cloud API token (if using Terraform Cloud)
+
+## Setting Up GitHub Secrets
+
+1. Go to your GitHub repository
+2. Click on "Settings" > "Secrets and variables" > "Actions"
+3. Click "New repository secret"
+4. Add each of the secrets listed above
+
+## AWS IAM Setup
+
+Create an IAM user with the following permissions:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:*",
+                "cloudfront:*",
+                "iam:GetPolicy",
+                "iam:GetPolicyVersion",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListPolicies",
+                "iam:ListPolicyVersions",
+                "iam:ListRoles"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+**Note**: For production environments, it's recommended to use more restrictive permissions.
+
+## Setting Up Terraform Backend (Optional)
+
+For team environments, it's recommended to use a remote backend for Terraform state. To set up an S3 backend:
+
+1. Create an S3 bucket for Terraform state:
+
+```bash
+aws s3api create-bucket --bucket your-terraform-state-bucket --region us-east-1
+```
+
+2. Enable versioning on the bucket:
+
+```bash
+aws s3api put-bucket-versioning --bucket your-terraform-state-bucket --versioning-configuration Status=Enabled
+```
+
+3. Create a DynamoDB table for state locking:
+
+```bash
+aws dynamodb create-table \
+  --table-name terraform-locks \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region us-east-1
+```
+
+4. Uncomment and update the backend configuration in `backend.tf`
+
+## Workflow Usage
+
+### Automated Deployments
+
+- **Pull Requests**: When you create a PR to the main branch, the workflow will run validation and planning steps
+- **Merges to Main**: When code is merged to the main branch, it will automatically deploy to the dev environment
+- **Manual Deployments**: You can manually trigger a deployment to any environment using the workflow dispatch event
+
+### Manual Deployment
+
+1. Go to the "Actions" tab in your repository
+2. Select the "Terraform CI/CD Pipeline" workflow
+3. Click "Run workflow"
+4. Select the branch and environment, then click "Run workflow"
+
+### Destroying Resources
+
+To destroy the infrastructure:
+
+1. Go to the "Actions" tab in your repository
+2. Select the "Terraform Destroy" workflow
+3. Click "Run workflow"
+4. Select the environment and type "destroy" to confirm
+5. Click "Run workflow"

--- a/backend.tf
+++ b/backend.tf
@@ -1,0 +1,12 @@
+# This file configures the Terraform backend for state storage
+# Uncomment and configure for your environment
+
+# terraform {
+#   backend "s3" {
+#     bucket         = "your-terraform-state-bucket"
+#     key            = "static-website/terraform.tfstate"
+#     region         = "us-east-1"
+#     dynamodb_table = "terraform-locks"
+#     encrypt        = true
+#   }
+# }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,251 @@
+# S3 bucket for website hosting
+resource "aws_s3_bucket" "website" {
+  bucket = var.bucket_name
+
+  tags = {
+    Name        = var.bucket_name
+    Environment = var.environment
+  }
+}
+
+# S3 bucket ACL
+resource "aws_s3_bucket_ownership_controls" "website" {
+  bucket = aws_s3_bucket.website.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "website" {
+  bucket = aws_s3_bucket.website.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# S3 bucket website configuration
+resource "aws_s3_bucket_website_configuration" "website" {
+  bucket = aws_s3_bucket.website.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+}
+
+# S3 bucket policy to allow CloudFront access
+resource "aws_s3_bucket_policy" "website" {
+  bucket = aws_s3_bucket.website.id
+  policy = data.aws_iam_policy_document.s3_policy.json
+}
+
+# IAM policy document for S3 bucket
+data "aws_iam_policy_document" "s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.website.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.website_distribution.arn]
+    }
+  }
+}
+
+# CloudFront Origin Access Control
+resource "aws_cloudfront_origin_access_control" "website_oac" {
+  name                              = "${var.bucket_name}-oac"
+  description                       = "OAC for ${var.bucket_name} S3 bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# CloudFront distribution
+resource "aws_cloudfront_distribution" "website_distribution" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  price_class         = var.cloudfront_price_class
+  comment             = "CloudFront distribution for ${var.bucket_name}"
+  wait_for_deployment = false
+
+  origin {
+    domain_name              = aws_s3_bucket.website.bucket_regional_domain_name
+    origin_id                = "S3-${var.bucket_name}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.website_oac.id
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "S3-${var.bucket_name}"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 10
+  }
+
+  tags = {
+    Name        = "${var.bucket_name}-distribution"
+    Environment = var.environment
+  }
+}
+
+# Sample index.html file
+resource "aws_s3_object" "index" {
+  bucket       = aws_s3_bucket.website.id
+  key          = "index.html"
+  content      = <<EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Static Website with Terraform</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            color: #333;
+            background-color: #f4f4f4;
+        }
+        .container {
+            width: 80%;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+        header {
+            background: #35424a;
+            color: white;
+            padding: 1rem;
+            text-align: center;
+        }
+        .content {
+            background: white;
+            padding: 2rem;
+            margin-top: 1rem;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Welcome to My Static Website</h1>
+    </header>
+    <div class="container">
+        <div class="content">
+            <h2>Hello World!</h2>
+            <p>This website is hosted on AWS S3 and delivered through CloudFront.</p>
+            <p>It was deployed using Terraform and GitHub Actions.</p>
+        </div>
+    </div>
+</body>
+</html>
+EOF
+  content_type = "text/html"
+}
+
+# Sample error.html file
+resource "aws_s3_object" "error" {
+  bucket       = aws_s3_bucket.website.id
+  key          = "error.html"
+  content      = <<EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Error - Page Not Found</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            color: #333;
+            background-color: #f4f4f4;
+            text-align: center;
+        }
+        .container {
+            width: 80%;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+        header {
+            background: #35424a;
+            color: white;
+            padding: 1rem;
+        }
+        .content {
+            background: white;
+            padding: 2rem;
+            margin-top: 1rem;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }
+        .error {
+            color: #e74c3c;
+            font-size: 5rem;
+            margin: 0;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Static Website</h1>
+    </header>
+    <div class="container">
+        <div class="content">
+            <p class="error">404</p>
+            <h2>Page Not Found</h2>
+            <p>The page you are looking for does not exist.</p>
+            <a href="/">Return to Home</a>
+        </div>
+    </div>
+</body>
+</html>
+EOF
+  content_type = "text/html"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,24 @@
+output "s3_bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = aws_s3_bucket.website.id
+}
+
+output "s3_bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = aws_s3_bucket.website.arn
+}
+
+output "s3_website_endpoint" {
+  description = "S3 website endpoint"
+  value       = aws_s3_bucket_website_configuration.website.website_endpoint
+}
+
+output "cloudfront_distribution_id" {
+  description = "ID of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.website_distribution.id
+}
+
+output "cloudfront_domain_name" {
+  description = "Domain name of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.website_distribution.domain_name
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  required_version = ">= 1.2.0"
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,7 @@
+# Example terraform.tfvars file
+# Copy this file to terraform.tfvars and update the values
+
+region                 = "us-east-1"
+bucket_name            = "my-static-website-bucket"
+environment            = "dev"
+cloudfront_price_class = "PriceClass_100"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,22 @@
+variable "region" {
+  description = "The AWS region to deploy resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket for the static website"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "cloudfront_price_class" {
+  description = "CloudFront price class (PriceClass_All, PriceClass_200, PriceClass_100)"
+  type        = string
+  default     = "PriceClass_100"
+}


### PR DESCRIPTION
## Description

This PR adds Terraform code to deploy a static website using AWS S3 and CloudFront, along with GitHub Actions workflows for CI/CD.

### Features Added:

- **Infrastructure as Code:**
  - S3 bucket configured for website hosting
  - CloudFront distribution with Origin Access Control
  - Sample HTML files (index.html and error.html)

- **CI/CD Pipeline:**
  - GitHub Actions workflow for Terraform validation, planning, and deployment
  - Support for multiple environments (dev, staging, prod)
  - Automated PR comments with plan results
  - Manual deployment trigger option

- **Documentation:**
  - Setup guide for GitHub Actions and AWS credentials
  - Terraform configuration documentation

### How to Use:

1. Set up the required GitHub secrets as described in SETUP.md
2. For automatic deployments, merge to main
3. For manual deployments, use the workflow_dispatch trigger

### Testing:

The Terraform code has been validated and tested locally.